### PR TITLE
Add funding information for GitHub and Cash App

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+
+github: backrat13
+
+cashapp: $frankhymer85


### PR DESCRIPTION
Updated funding options with GitHub username and Cash App.

## Summary by Sourcery

Chores:
- Configure GitHub funding metadata with GitHub username and Cash App handle.